### PR TITLE
Added Helm Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openapi-merger
 
-Serves a single merged [`OpenAPI`](https://swagger.io/specification/) spec based on any number of OpenAPI specs defined under `paths` in [`values.yaml`](helm/wasp-open-api/values.yaml).
+Serves a single merged [`OpenAPI`](https://swagger.io/specification/) spec based on any number of OpenAPI specs defined under `paths` in [`values.yaml`](https://github.com/digicatapult/helm-charts/blob/main/charts/wasp-open-api/values.yaml).
 
 Includes a node service with three endpoints:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/openapi-merger",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Amalgamated API specs for openapi",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Missed from previous PR `https://github.com/digicatapult/helm-charts/blob/main/charts/wasp-open-api/values.yaml`
