### PR TITLE
Added envar API_DOCS_URL_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ npm test
 | LOG_LEVEL          |    N     |      `info`       | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | PORT               |    N     |       `80`        | Port on which the service will listen                                                |
 | API_DOCS_FILE_PATH |    N     | `./api-docs.json` | Location of the api-docs file on the filesystem                                      |
+| API_DOCS_URL_PATH  |    N     |    `/api-docs`    | URL of the api-docs                                                                  |

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ npm test
 | LOG_LEVEL          |    N     |      `info`       | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | PORT               |    N     |       `80`        | Port on which the service will listen                                                |
 | API_DOCS_FILE_PATH |    N     | `./api-docs.json` | Location of the api-docs file on the filesystem                                      |
-| API_DOCS_URL_PATH  |    N     |    `/api-docs`    | URL of the api-docs                                                                  |
+| API_DOCS_URL_PATH  |    N     |    `/api-docs`    | URL to access the api-docs                                                           |

--- a/app/env.js
+++ b/app/env.js
@@ -12,6 +12,7 @@ const vars = envalid.cleanEnv(
     LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
     PORT: envalid.port({ default: 80, devDefault: 3000 }),
     API_DOCS_FILE_PATH: envalid.str({ default: './api-docs.json' }),
+    API_DOCS_URL_PATH: envalid.str({ default: '/api-docs' }),
   },
   {
     strict: true,

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ import fs from 'fs'
 import env from './env.js'
 import logger from './logger.js'
 
-const { PORT, API_DOCS_FILE_PATH } = env
+const { PORT, API_DOCS_FILE_PATH, API_DOCS_URL_PATH } = env
 
 async function createHttpServer() {
   const app = express()
@@ -28,7 +28,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `/api-docs`,
+          url: API_DOCS_URL_PATH,
         },
       ],
     },

--- a/app/server.js
+++ b/app/server.js
@@ -51,7 +51,7 @@ async function createHttpServer() {
     }
   })
 
-  app.get('/api-docs', async (req, res) => {
+  app.get(API_DOCS_URL_PATH, async (req, res) => {
     fs.readFile(API_DOCS_FILE_PATH, (err, data) => {
       if (err) {
         res.status(500).send({ error: 'failed to read OpenAPI doc' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/openapi-merger",
-      "version": "1.0.69",
+      "version": "1.0.70",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Amalgamated API specs for openapi",
   "main": "app/index.js",
   "scripts": {

--- a/test/httpServer.test.js
+++ b/test/httpServer.test.js
@@ -52,7 +52,7 @@ describe('API docs', async function () {
   describe('Get API docs', async function () {
     it('should return API docs', async function () {
       await context.request.post('/set-api-docs').send(apiDoc)
-      context.response = await context.request.get('/api-docs')
+      context.response = await context.request.get('/test/api-docs')
       expect(context.response.status).to.equal(200)
       expect(context.response.body).to.deep.equal(apiDoc)
     })

--- a/test/test.env
+++ b/test/test.env
@@ -1,2 +1,3 @@
 LOG_LEVEL=error
 API_DOCS_FILE_PATH=./test/data/api-docs.json
+API_DOCS_URL_PATH = "/test/api-docs"


### PR DESCRIPTION
# Changes 
- added envar API_DOCS_URL_PATH so we can specify the docs url
- behaviour unchanged 

# Ticket: 
- https://digicatapult.atlassian.net/browse/L3-248
