### PR TITLE
added api-public-url-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ npm test
 
 `openapi-merger` is configured primarily using environment variables as follows:
 
-| variable           | required |      default      | description                                                                          |
-| :----------------- | :------: | :---------------: | :----------------------------------------------------------------------------------- |
-| LOG_LEVEL          |    N     |      `info`       | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
-| PORT               |    N     |       `80`        | Port on which the service will listen                                                |
-| API_DOCS_FILE_PATH |    N     | `./api-docs.json` | Location of the api-docs file on the filesystem                                      |
-| API_DOCS_URL_PATH  |    N     |    `/api-docs`    | URL to access the api-docs                                                           |
+| variable              | required |      default      | description                                                                          |
+| :-------------------- | :------: | :---------------: | :----------------------------------------------------------------------------------- |
+| LOG_LEVEL             |    N     |      `info`       | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
+| PORT                  |    N     |       `80`        | Port on which the service will listen                                                |
+| API_DOCS_FILE_PATH    |    N     | `./api-docs.json` | Location of the api-docs file on the filesystem                                      |
+| API_PUBLIC_URL_PREFIX |    N     |        ``         | Public prefix to prepend for accessing api-docs                                      |

--- a/app/env.js
+++ b/app/env.js
@@ -12,7 +12,7 @@ const vars = envalid.cleanEnv(
     LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
     PORT: envalid.port({ default: 80, devDefault: 3000 }),
     API_DOCS_FILE_PATH: envalid.str({ default: './api-docs.json' }),
-    API_DOCS_URL_PATH: envalid.str({ default: '/api-docs' }),
+    API_PUBLIC_URL_PREFIX: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ import fs from 'fs'
 import env from './env.js'
 import logger from './logger.js'
 
-const { PORT, API_DOCS_FILE_PATH, API_DOCS_URL_PATH } = env
+const { PORT, API_DOCS_FILE_PATH, API_PUBLIC_URL_PREFIX } = env
 
 async function createHttpServer() {
   const app = express()
@@ -28,7 +28,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: API_DOCS_URL_PATH,
+          url: `${API_PUBLIC_URL_PREFIX}/api-docs`,
         },
       ],
     },
@@ -51,7 +51,7 @@ async function createHttpServer() {
     }
   })
 
-  app.get(API_DOCS_URL_PATH, async (req, res) => {
+  app.get(`/api-docs`, async (req, res) => {
     fs.readFile(API_DOCS_FILE_PATH, (err, data) => {
       if (err) {
         res.status(500).send({ error: 'failed to read OpenAPI doc' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/openapi-merger",
-      "version": "1.0.70",
+      "version": "1.0.71",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Amalgamated API specs for openapi",
   "main": "app/index.js",
   "scripts": {

--- a/test/httpServer.test.js
+++ b/test/httpServer.test.js
@@ -52,9 +52,18 @@ describe('API docs', async function () {
   describe('Get API docs', async function () {
     it('should return API docs', async function () {
       await context.request.post('/set-api-docs').send(apiDoc)
-      context.response = await context.request.get('/test/api-docs')
+      context.response = await context.request.get('/api-docs')
       expect(context.response.status).to.equal(200)
       expect(context.response.body).to.deep.equal(apiDoc)
+    })
+  })
+
+  describe('Get swagger with docs', async function () {
+    it('should return swagger with text in there', async function () {
+      await context.request.post('/set-api-docs').send(apiDoc)
+      context.response = await context.request.get('/swagger/')
+      expect(context.response.status).to.equal(200)
+      expect(context.response.text).to.not.be.empty
     })
   })
 })

--- a/test/test.env
+++ b/test/test.env
@@ -1,3 +1,3 @@
 LOG_LEVEL=error
 API_DOCS_FILE_PATH=./test/data/api-docs.json
-API_DOCS_URL_PATH = "/test/api-docs"
+API_PUBLIC_URL_PREFIX = "/test"


### PR DESCRIPTION
# Changes 
- removed API_DOCS_FILE_PATH, instead using API_PUBLIC_URL_PREFIX
- updated GET /api-docs endpoint 

# Question 
- not really sure how to check the swagger is bringing back the correct path for api-docs 