### PR TITLE
Upgrade npm to patch bundled tar vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM node:24-alpine
 
+RUN npm install -g npm@12.0.1
+
 # Allow log level to be controlled. Uses an argument name that is different
 # from the existing environment variable, otherwise the environment variable
 # shadows the argument.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.2.53",
+  "version": "1.2.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/openapi-merger",
-      "version": "1.2.53",
+      "version": "1.2.54",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "engines": {
         "node": "24.x",
-        "npm": "11.x"
+        "npm": "12.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "engines": {
     "node": "24.x",
-    "npm": "11.x"
+    "npm": "12.x"
   },
   "keywords": [
     "openapi"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/openapi-merger",
-  "version": "1.2.53",
+  "version": "1.2.54",
   "description": "Amalgamated API specs for openapi",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

- Upgrade the npm bundled in the production image because [Trivy reports CVEs in its transitive `tar` dependency](https://github.com/digicatapult/openapi-merger/actions/runs/30305792256/job/90109990548).

## Detailed description


## Additional context
